### PR TITLE
Fix TLS config reload race

### DIFF
--- a/common/certificate/store.go
+++ b/common/certificate/store.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/sagernet/fswatch"
 	"github.com/sagernet/sing-box/adapter"
@@ -21,6 +22,7 @@ import (
 var _ adapter.CertificateStore = (*Store)(nil)
 
 type Store struct {
+	access                    sync.RWMutex
 	systemPool                *x509.CertPool
 	currentPool               *x509.CertPool
 	certificate               string
@@ -88,6 +90,9 @@ func NewStore(ctx context.Context, logger logger.Logger, options option.Certific
 	}
 	err := store.update()
 	if err != nil {
+		if store.watcher != nil {
+			_ = store.watcher.Close()
+		}
 		return nil, E.Cause(err, "initializing certificate store")
 	}
 	return store, nil
@@ -102,7 +107,10 @@ func (s *Store) Start(stage adapter.StartStage) error {
 		return nil
 	}
 	if s.watcher != nil {
-		return s.watcher.Start()
+		if err := s.watcher.Start(); err != nil {
+			_ = s.watcher.Close()
+			return err
+		}
 	}
 	return nil
 }
@@ -115,10 +123,15 @@ func (s *Store) Close() error {
 }
 
 func (s *Store) Pool() *x509.CertPool {
-	return s.currentPool
+	s.access.RLock()
+	pool := s.currentPool
+	s.access.RUnlock()
+	return pool
 }
 
 func (s *Store) update() error {
+	s.access.Lock()
+	defer s.access.Unlock()
 	var currentPool *x509.CertPool
 	if s.systemPool == nil {
 		currentPool = x509.NewCertPool()

--- a/common/tls/std_server.go
+++ b/common/tls/std_server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sagernet/fswatch"
@@ -20,6 +21,7 @@ import (
 var errInsecureUnused = E.New("tls: insecure unused")
 
 type STDServerConfig struct {
+	access          sync.RWMutex
 	config          *tls.Config
 	logger          log.Logger
 	acmeService     adapter.SimpleLifecycle
@@ -31,45 +33,70 @@ type STDServerConfig struct {
 	watcher         *fswatch.Watcher
 }
 
+func (c *STDServerConfig) getConfig() *tls.Config {
+	c.access.RLock()
+	cfg := c.config
+	c.access.RUnlock()
+	return cfg
+}
+
+func (c *STDServerConfig) updateConfig(update func(*tls.Config) error) error {
+	c.access.Lock()
+	cfg := c.config.Clone()
+	err := update(cfg)
+	if err == nil {
+		c.config = cfg
+	}
+	c.access.Unlock()
+	return err
+}
+
 func (c *STDServerConfig) ServerName() string {
-	return c.config.ServerName
+	return c.getConfig().ServerName
 }
 
 func (c *STDServerConfig) SetServerName(serverName string) {
-	c.config.ServerName = serverName
+	_ = c.updateConfig(func(cfg *tls.Config) error {
+		cfg.ServerName = serverName
+		return nil
+	})
 }
 
 func (c *STDServerConfig) NextProtos() []string {
-	if c.acmeService != nil && len(c.config.NextProtos) > 1 && c.config.NextProtos[0] == ACMETLS1Protocol {
-		return c.config.NextProtos[1:]
+	cfg := c.getConfig()
+	if c.acmeService != nil && len(cfg.NextProtos) > 1 && cfg.NextProtos[0] == ACMETLS1Protocol {
+		return cfg.NextProtos[1:]
 	} else {
-		return c.config.NextProtos
+		return cfg.NextProtos
 	}
 }
 
 func (c *STDServerConfig) SetNextProtos(nextProto []string) {
-	if c.acmeService != nil && len(c.config.NextProtos) > 1 && c.config.NextProtos[0] == ACMETLS1Protocol {
-		c.config.NextProtos = append(c.config.NextProtos[:1], nextProto...)
-	} else {
-		c.config.NextProtos = nextProto
-	}
+	_ = c.updateConfig(func(cfg *tls.Config) error {
+		if c.acmeService != nil && len(cfg.NextProtos) > 1 && cfg.NextProtos[0] == ACMETLS1Protocol {
+			cfg.NextProtos = append(cfg.NextProtos[:1], nextProto...)
+		} else {
+			cfg.NextProtos = nextProto
+		}
+		return nil
+	})
 }
 
 func (c *STDServerConfig) Config() (*STDConfig, error) {
-	return c.config, nil
+	return c.getConfig(), nil
 }
 
 func (c *STDServerConfig) Client(conn net.Conn) (Conn, error) {
-	return tls.Client(conn, c.config), nil
+	return tls.Client(conn, c.getConfig()), nil
 }
 
 func (c *STDServerConfig) Server(conn net.Conn) (Conn, error) {
-	return tls.Server(conn, c.config), nil
+	return tls.Server(conn, c.getConfig()), nil
 }
 
 func (c *STDServerConfig) Clone() Config {
 	return &STDServerConfig{
-		config: c.config.Clone(),
+		config: c.getConfig().Clone(),
 	}
 }
 
@@ -113,6 +140,7 @@ func (c *STDServerConfig) startWatcher() error {
 	}
 	err = watcher.Start()
 	if err != nil {
+		watcher.Close()
 		return err
 	}
 	c.watcher = watcher
@@ -138,10 +166,18 @@ func (c *STDServerConfig) certificateUpdated(path string) error {
 		if err != nil {
 			return E.Cause(err, "reload key pair")
 		}
-		c.config.Certificates = []tls.Certificate{keyPair}
+		err = c.updateConfig(func(cfg *tls.Config) error {
+			cfg.Certificates = []tls.Certificate{keyPair}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
 		c.logger.Info("reloaded TLS certificate")
 	} else if path == c.echKeyPath {
-		err := reloadECHKeys(c.echKeyPath, c.config)
+		err := c.updateConfig(func(cfg *tls.Config) error {
+			return reloadECHKeys(c.echKeyPath, cfg)
+		})
 		if err != nil {
 			return err
 		}

--- a/dns/transport/quic/quic.go
+++ b/dns/transport/quic/quic.go
@@ -37,7 +37,7 @@ type Transport struct {
 	dialer     N.Dialer
 	serverAddr M.Socksaddr
 	tlsConfig  tls.Config
-	access     sync.Mutex
+	access     sync.RWMutex
 	connection quic.EarlyConnection
 }
 
@@ -78,8 +78,9 @@ func (t *Transport) Start(stage adapter.StartStage) error {
 
 func (t *Transport) Close() error {
 	t.access.Lock()
-	defer t.access.Unlock()
 	connection := t.connection
+	t.connection = nil
+	t.access.Unlock()
 	if connection != nil {
 		connection.CloseWithError(0, "")
 	}
@@ -111,18 +112,21 @@ func (t *Transport) Exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.Msg,
 }
 
 func (t *Transport) openConnection() (quic.EarlyConnection, error) {
+	t.access.RLock()
 	connection := t.connection
+	t.access.RUnlock()
 	if connection != nil && !common.Done(connection.Context()) {
 		return connection, nil
 	}
 	t.access.Lock()
-	defer t.access.Unlock()
 	connection = t.connection
 	if connection != nil && !common.Done(connection.Context()) {
+		t.access.Unlock()
 		return connection, nil
 	}
 	conn, err := t.dialer.DialContext(t.ctx, N.NetworkUDP, t.serverAddr)
 	if err != nil {
+		t.access.Unlock()
 		return nil, err
 	}
 	earlyConnection, err := sQUIC.DialEarly(
@@ -133,9 +137,11 @@ func (t *Transport) openConnection() (quic.EarlyConnection, error) {
 		nil,
 	)
 	if err != nil {
+		t.access.Unlock()
 		return nil, err
 	}
 	t.connection = earlyConnection
+	t.access.Unlock()
 	return earlyConnection, nil
 }
 

--- a/transport/v2rayquic/client.go
+++ b/transport/v2rayquic/client.go
@@ -28,7 +28,7 @@ type Client struct {
 	serverAddr M.Socksaddr
 	tlsConfig  tls.Config
 	quicConfig *quic.Config
-	connAccess sync.Mutex
+	connAccess sync.RWMutex
 	conn       quic.Connection
 	rawConn    net.Conn
 }
@@ -49,8 +49,15 @@ func NewClient(ctx context.Context, dialer N.Dialer, serverAddr M.Socksaddr, opt
 	}, nil
 }
 
-func (c *Client) offer() (quic.Connection, error) {
+func (c *Client) getConn() quic.Connection {
+	c.connAccess.RLock()
 	conn := c.conn
+	c.connAccess.RUnlock()
+	return conn
+}
+
+func (c *Client) offer() (quic.Connection, error) {
+	conn := c.getConn()
 	if conn != nil && !common.Done(conn.Context()) {
 		return conn, nil
 	}


### PR DESCRIPTION
## Summary
- guard TLS config updates with RWMutex to avoid races
- clone config when reloading certificates or ECH keys
- fix quic connection race by protecting shared connections with RWMutex
- close fswatch watcher if startup fails and protect certificate pool with a lock

## Testing
- `go vet -tags 'with_quic with_gvisor with_dhcp with_wireguard with_utls with_acme with_clash_api with_tailscale' ./...`
- `go test -tags 'with_quic with_gvisor with_dhcp with_wireguard with_utls with_acme with_clash_api with_tailscale' ./... -run TestNonExistent` *(fails: build failed for service/derp)*

------
https://chatgpt.com/codex/tasks/task_b_68781f837f80832297d3538c7c40d78d