### PR TITLE
Prevent WireGuard system interfaces from routing peer endpoints

### DIFF
--- a/protocol/wireguard/outbound.go
+++ b/protocol/wireguard/outbound.go
@@ -83,6 +83,12 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 			Reserved:     options.Reserved,
 		}}
 	}
+	var routeExclude []netip.Addr
+	for _, peer := range peers {
+		if peer.Endpoint.Addr.IsValid() {
+			routeExclude = append(routeExclude, peer.Endpoint.Addr)
+		}
+	}
 	wgEndpoint, err := wireguard.NewEndpoint(wireguard.EndpointOptions{
 		Context: ctx,
 		Logger:  logger,
@@ -93,10 +99,11 @@ func NewOutbound(ctx context.Context, router adapter.Router, logger log.ContextL
 				BindInterface: interfaceName,
 			}))
 		},
-		Name:       options.InterfaceName,
-		MTU:        options.MTU,
-		Address:    options.LocalAddress,
-		PrivateKey: options.PrivateKey,
+		Name:         options.InterfaceName,
+		MTU:          options.MTU,
+		Address:      options.LocalAddress,
+		RouteExclude: routeExclude,
+		PrivateKey:   options.PrivateKey,
 		ResolvePeer: func(domain string) (netip.Addr, error) {
 			endpointAddresses, lookupErr := outbound.dnsRouter.Lookup(ctx, domain, outboundDialer.(dialer.ResolveDialer).QueryOptions())
 			if lookupErr != nil {

--- a/transport/wireguard/device.go
+++ b/transport/wireguard/device.go
@@ -33,6 +33,7 @@ type DeviceOptions struct {
 	MTU            uint32
 	Address        []netip.Prefix
 	AllowedAddress []netip.Prefix
+	RouteExclude   []netip.Addr
 }
 
 func NewDevice(options DeviceOptions) (Device, error) {

--- a/transport/wireguard/device_system.go
+++ b/transport/wireguard/device_system.go
@@ -22,14 +22,16 @@ import (
 var _ Device = (*systemDevice)(nil)
 
 type systemDevice struct {
-	options      DeviceOptions
-	dialer       N.Dialer
-	device       tun.Tun
-	batchDevice  tun.LinuxTUN
-	events       chan wgTun.Event
-	closeOnce    sync.Once
-	inet4Address netip.Addr
-	inet6Address netip.Addr
+	options           DeviceOptions
+	dialer            N.Dialer
+	device            tun.Tun
+	batchDevice       tun.LinuxTUN
+	events            chan wgTun.Event
+	closeOnce         sync.Once
+	inet4Address      netip.Addr
+	inet6Address      netip.Addr
+	inet4RouteExclude []netip.Prefix
+	inet6RouteExclude []netip.Prefix
 }
 
 func newSystemDevice(options DeviceOptions) (*systemDevice, error) {
@@ -38,6 +40,8 @@ func newSystemDevice(options DeviceOptions) (*systemDevice, error) {
 	}
 	var inet4Address netip.Addr
 	var inet6Address netip.Addr
+	var inet4RouteExclude []netip.Prefix
+	var inet6RouteExclude []netip.Prefix
 	if len(options.Address) > 0 {
 		if prefix := common.Find(options.Address, func(it netip.Prefix) bool {
 			return it.Addr().Is4()
@@ -52,12 +56,24 @@ func newSystemDevice(options DeviceOptions) (*systemDevice, error) {
 			inet6Address = prefix.Addr()
 		}
 	}
+	for _, addr := range options.RouteExclude {
+		if !addr.IsValid() {
+			continue
+		}
+		if addr.Is4() {
+			inet4RouteExclude = append(inet4RouteExclude, netip.PrefixFrom(addr, 32))
+		} else if addr.Is6() {
+			inet6RouteExclude = append(inet6RouteExclude, netip.PrefixFrom(addr, 128))
+		}
+	}
 	return &systemDevice{
-		options:      options,
-		dialer:       options.CreateDialer(options.Name),
-		events:       make(chan wgTun.Event, 1),
-		inet4Address: inet4Address,
-		inet6Address: inet6Address,
+		options:           options,
+		dialer:            options.CreateDialer(options.Name),
+		events:            make(chan wgTun.Event, 1),
+		inet4Address:      inet4Address,
+		inet6Address:      inet6Address,
+		inet4RouteExclude: inet4RouteExclude,
+		inet6RouteExclude: inet6RouteExclude,
 	}, nil
 }
 
@@ -96,10 +112,12 @@ func (w *systemDevice) Start() error {
 		Inet4RouteAddress: common.Filter(w.options.AllowedAddress, func(it netip.Prefix) bool {
 			return it.Addr().Is4()
 		}),
-		Inet6RouteAddress: common.Filter(w.options.AllowedAddress, func(it netip.Prefix) bool { return it.Addr().Is6() }),
-		InterfaceMonitor:  networkManager.InterfaceMonitor(),
-		InterfaceFinder:   networkManager.InterfaceFinder(),
-		Logger:            w.options.Logger,
+		Inet6RouteAddress:        common.Filter(w.options.AllowedAddress, func(it netip.Prefix) bool { return it.Addr().Is6() }),
+		Inet4RouteExcludeAddress: w.inet4RouteExclude,
+		Inet6RouteExcludeAddress: w.inet6RouteExclude,
+		InterfaceMonitor:         networkManager.InterfaceMonitor(),
+		InterfaceFinder:          networkManager.InterfaceFinder(),
+		Logger:                   w.options.Logger,
 	}
 	// works with Linux, macOS with IFSCOPE routes, not tested on Windows
 	if runtime.GOOS == "darwin" {

--- a/transport/wireguard/endpoint.go
+++ b/transport/wireguard/endpoint.go
@@ -114,6 +114,7 @@ func NewEndpoint(options EndpointOptions) (*Endpoint, error) {
 		MTU:            options.MTU,
 		Address:        options.Address,
 		AllowedAddress: allowedAddresses,
+		RouteExclude:   options.RouteExclude,
 	}
 	tunDevice, err := NewDevice(deviceOptions)
 	if err != nil {

--- a/transport/wireguard/endpoint_options.go
+++ b/transport/wireguard/endpoint_options.go
@@ -22,6 +22,7 @@ type EndpointOptions struct {
 	Name         string
 	MTU          uint32
 	Address      []netip.Prefix
+	RouteExclude []netip.Addr
 	PrivateKey   string
 	ListenPort   uint16
 	ResolvePeer  func(domain string) (netip.Addr, error)


### PR DESCRIPTION
## Summary
- collect WireGuard peer endpoint IPs when building an outbound and pass them to the transport layer
- extend system WireGuard device options to exclude peer endpoint routes when configuring the system interface

## Testing
- `go test ./...` *(fails: dial tcp 1.1.1.1:443: connect: network is unreachable; missing gvisor build tags for tailscale packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b0782fb8833295d7ba816862987b